### PR TITLE
use defineProperty to declare function.

### DIFF
--- a/find.js
+++ b/find.js
@@ -1,19 +1,25 @@
 'use strict';
 
-Array.prototype.find = Array.prototype.find || function(callback) {
-  if (this === null) {
-    throw new TypeError('Array.prototype.find called on null or undefined');
-  } else if (typeof callback !== 'function') {
-    throw new TypeError('callback must be a function');
-  }
-  var list = Object(this);
-  // Makes sures is always has an positive integer as length.
-  var length = list.length >>> 0;
-  var thisArg = arguments[1];
-  for (var i = 0; i < length; i++) {
-    var element = list[i];
-    if ( callback.call(thisArg, element, i, list) ) {
-      return element;
+//Array.prototype.find = Array.prototype.find || function(callback) {
+if (!Array.prototype.find) {
+  //Define as Property otherwise for(x in y) will loop over the function.
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(callback){
+      if (this === null) {
+        throw new TypeError('Array.prototype.find called on null or undefined');
+      } else if (typeof callback !== 'function') {
+        throw new TypeError('callback must be a function');
+      }
+      var list = Object(this);
+      // Makes sures is always has an positive integer as length.
+      var length = list.length >>> 0;
+      var thisArg = arguments[1];
+      for (var i = 0; i < length; i++) {
+        var element = list[i];
+        if ( callback.call(thisArg, element, i, list) ) {
+          return element;
+        }
+      }
     }
-  }
-};
+  });
+}


### PR DESCRIPTION
This converts the old declaration which confuses code such as `for(x in y)` which iterates over the array object to being declared using defineProperty which doesn't cause the issue.

Fixes jsPolyfill/Array.prototype.find#2